### PR TITLE
Add testing datadirs

### DIFF
--- a/benchutils/metrics.py
+++ b/benchutils/metrics.py
@@ -199,7 +199,6 @@ def _load_observed_profiles(observed_files, rank, methods, prefix=''):
     # merge a bunch of dataframes loaded with `load_observed_single_profile
     dfs = []
     for observed_file, method in zip(observed_files, methods):
-        assert method in observed_file
         dfs.append(_load_observed_single_profile(observed_file,
                                                  rank,
                                                  suffix=method,

--- a/benchutils/tests/data/expected_genus_profile.txt
+++ b/benchutils/tests/data/expected_genus_profile.txt
@@ -1,0 +1,9 @@
+@SampleID:
+@Version:0.9.1
+@Ranks:superkingdom|phylum|class|order|family|genus|species|strain
+
+@@TAXID	RANK	TAXPATH	TAXPATHSN	PERCENTAGE	_CAMI_genomeID	_CAMI_OTU
+1	genus	9|8|7|6|5|1	Bacteria|blah8|blah7|blah6|blah5|blah1	50
+2	genus	9|8|7|6|5|2	Bacteria|blah8|blah7|blah6|blah5|blah2	20
+3	genus	9|8|7|6|5|3	Bacteria|blah8|blah7|blah6|blah5|blah3	20
+4	genus	9|8|7|6|5|4	Bacteria|blah8|blah7|blah6|blah5|blah4	10

--- a/benchutils/tests/data/sample_genus_profile1.txt
+++ b/benchutils/tests/data/sample_genus_profile1.txt
@@ -1,0 +1,4 @@
+@@TAXID	RANK	TAXNAME	PERCENTAGE
+1	genus	blank	75
+2	genus	blank	15
+3	genus	blank	10

--- a/benchutils/tests/data/sample_genus_profile2.txt
+++ b/benchutils/tests/data/sample_genus_profile2.txt
@@ -1,0 +1,4 @@
+@@TAXID	RANK	TAXNAME	PERCENTAGE
+1	genus	blank	65
+2	genus	blank	10
+4	genus	blank	25

--- a/benchutils/tests/test_metrics.py
+++ b/benchutils/tests/test_metrics.py
@@ -96,10 +96,14 @@ class TestMetrics(unittest.TestCase):
 class TestProfileError(testbase.BaseTestCase):
 
     def test_errors_metric_not_in_available_metrics(self):
-        pass
+        with self.assertRaisesRegex(ValueError, 'not in available metrics'):
+            profile_error('foo', 'bar', 'baz', rank='genus',
+                          methods='qux', metric='quux')
 
     def test_errors_rank_not_in_ranks(self):
-        pass
+        with self.assertRaisesRegex(ValueError, 'not in available ranks'):
+            profile_error('foo', 'bar', 'baz', rank='qux', methods='quux',
+                          metric='f1')
 
     def test_runs_metric_auprc(self):
         pass

--- a/benchutils/tests/test_metrics.py
+++ b/benchutils/tests/test_metrics.py
@@ -95,6 +95,12 @@ class TestMetrics(unittest.TestCase):
 # TODO test these (blocked by unittest filesystem)
 class TestProfileError(testbase.BaseTestCase):
 
+    def setUp(self):
+        super(TestProfileError, self).setUp()
+        self.exp = self.get_data_path('expected_genus_profile.txt')
+        self.obs1 = self.get_data_path('sample_genus_profile1.txt')
+        self.obs2 = self.get_data_path('sample_genus_profile2.txt')
+
     def test_errors_metric_not_in_available_metrics(self):
         with self.assertRaisesRegex(ValueError, 'not in available metrics'):
             profile_error('foo', 'bar', 'baz', rank='genus',
@@ -106,22 +112,61 @@ class TestProfileError(testbase.BaseTestCase):
                           metric='f1')
 
     def test_runs_metric_auprc(self):
-        pass
+        out1 = self.create_data_path('test_runs_with_metric_auprc1.txt')
+        out2 = self.create_data_path('test_runs_with_metric_auprc2.txt')
+        profile_error(self.obs1, self.exp, out1, rank='genus',
+                      methods='auprc', metric='auprc')
+        profile_error([self.obs1, self.obs1], self.exp, out2, rank='genus',
+                      methods=['auprc', 'auprc'], metric='auprc')
 
     def test_runs_metric_pearsonr(self):
-        pass
+        out1 = self.create_data_path('test_runs_with_metric_pearsonr1.txt')
+        out2 = self.create_data_path('test_runs_with_metric_pearsonr2.txt')
+        profile_error(self.obs1, self.exp, out1, rank='genus',
+                      methods='pearsonr', metric='pearsonr')
+        profile_error([self.obs1, self.obs1], self.exp, out2, rank='genus',
+                      methods=['pearsonr', 'pearsonr'], metric='pearsonr')
 
     def test_runs_metric_rmse(self):
-        pass
+        out1 = self.create_data_path('test_runs_with_metric_rmse1.txt')
+        out2 = self.create_data_path('test_runs_with_metric_rmse2.txt')
+        profile_error(self.obs1, self.exp, out1, rank='genus',
+                      methods='absolute_error', metric='absolute_error')
+        profile_error([self.obs1, self.obs1], self.exp, out2, rank='genus',
+                      methods=['absolute_error', 'absolute_error'],
+                      metric='absolute_error')
+
+    def test_runs_metric_l1_norm(self):
+        out1 = self.create_data_path('test_runs_with_metric_l1_norm1.txt')
+        out2 = self.create_data_path('test_runs_with_metric_l1_norm2.txt')
+        profile_error(self.obs1, self.exp, out1, rank='genus',
+                      methods='l1_norm', metric='l1_norm')
+        profile_error([self.obs1, self.obs1], self.exp, out2, rank='genus',
+                      methods=['l1_norm', 'l1_norm'], metric='l1_norm')
 
     def test_runs_metric_l2_norm(self):
-        pass
+        out1 = self.create_data_path('test_runs_with_metric_l2_norm1.txt')
+        out2 = self.create_data_path('test_runs_with_metric_l2_norm2.txt')
+        profile_error(self.obs1, self.exp, out1, rank='genus',
+                      methods='l2_norm', metric='l2_norm')
+        profile_error([self.obs1, self.obs1], self.exp, out2, rank='genus',
+                      methods=['l2_norm', 'l2_norm'], metric='l2_norm')
 
-    def test_runs_with_list(self):
-        pass
+    def test_runs_metric_precision(self):
+        out1 = self.create_data_path('test_runs_with_metric_precision1.txt')
+        out2 = self.create_data_path('test_runs_with_metric_precision2.txt')
+        profile_error(self.obs1, self.exp, out1, rank='genus',
+                      methods='precision', metric='precision')
+        profile_error([self.obs1, self.obs1], self.exp, out2, rank='genus',
+                      methods=['precision', 'precision'], metric='precision')
 
-    def test_runs_with_string(self):
-        pass
+    def test_runs_metric_recall(self):
+        out1 = self.create_data_path('test_runs_with_metric_recall1.txt')
+        out2 = self.create_data_path('test_runs_with_metric_recall2.txt')
+        profile_error(self.obs1, self.exp, out1, rank='genus',
+                      methods='recall', metric='recall')
+        profile_error([self.obs1, self.obs1], self.exp, out2, rank='genus',
+                      methods=['recall', 'recall'], metric='recall')
 
 
 if __name__ == '__main__':

--- a/benchutils/tests/test_metrics.py
+++ b/benchutils/tests/test_metrics.py
@@ -3,7 +3,8 @@ import numpy as np
 import pandas as pd
 
 from benchutils.metrics import (precision, recall, f1, l1_norm, l2_norm, auprc,
-                                pearsonr, rmse)
+                                pearsonr, rmse, profile_error)
+from benchutils.tests import testbase
 
 
 class TestMetrics(unittest.TestCase):
@@ -92,7 +93,7 @@ class TestMetrics(unittest.TestCase):
 
 
 # TODO test these (blocked by unittest filesystem)
-class TestProfileError(unittest.TestCase):
+class TestProfileError(testbase.BaseTestCase):
 
     def test_errors_metric_not_in_available_metrics(self):
         pass

--- a/benchutils/tests/test_plotting.py
+++ b/benchutils/tests/test_plotting.py
@@ -1,36 +1,33 @@
 import unittest
-
+from benchutils.tests import testbase
 from benchutils import plotting
 
 
 # TODO test errors (blocked by checking errors in plotting.py)
-class TestMetricComparisonPlot(unittest.TestCase):
-    # TODO get test filepaths with some more sophisticated way for demo data
-    #  and run it on them, and keep track of files to delete after running
-    #  unit tests
+class TestMetricComparisonPlot(testbase.BaseTestCase):
     def test_runs_metric_comparison_plot(self):
-        plotting.metric_comparison_plot('benchutils/tests/data/summaries/'
-                                        '2019.08.07_10.20.59_sample_0.genus'
-                                        '.absolute_error.txt',
-                                        'benchutils/tests/data/summaries/'
-                                        '2019.08.07_10.20.59_sample_0.genus'
-                                        '.correlation.txt',
-                                        'benchutils/tests/data/summaries/'
-                                        'test_metric_plot.svg')
+        abs_error_file = self.get_data_path('summaries/2019.08.07_10.20.59_'
+                                            'sample_0.genus.absolute_error'
+                                            '.txt')
+        corr_file = self.get_data_path('summaries/2019.08.07_10.20.59_sample_0'
+                                       '.genus.correlation.txt')
+
+        test_metric_plot = self.create_data_path(
+            'summaries/test_metric_plot.svg')
+
+        plotting.metric_comparison_plot(abs_error_file, corr_file,
+                                        test_metric_plot)
 
 
 # TODO test errors (blocked by checking errors in plotting.py)
-class TestMethodComparisonPlot(unittest.TestCase):
-    # TODO refactor with more sophisticated file path getters
+class TestMethodComparisonPlot(testbase.BaseTestCase):
     def test_runs_method_comparison_plot(self):
-        plotting.method_comparison_plot(['benchutils/tests/data/summaries/'
-                                         '2019.08.07_10.20.59_sample_0.genus'
-                                         '.correlation.txt',
-                                         'benchutils/tests/data/summaries/'
-                                         '2019.08.07_10.20.59_sample_1.genus'
-                                         '.correlation.txt'],
-                                        'benchutils/tests/data/summaries/'
-                                        'test_method_plot.svg')
+        sample1 = self.get_data_path(
+            'summaries/2019.08.07_10.20.59_sample_0.genus.correlation.txt')
+        sample2 = self.get_data_path(
+            'summaries/2019.08.07_10.20.59_sample_1.genus.correlation.txt')
+        plot = self.create_data_path('summaries/test_method_plot.svg')
+        plotting.method_comparison_plot([sample1, sample2], plot)
 
 
 if __name__ == '__main__':

--- a/benchutils/tests/test_transformers.py
+++ b/benchutils/tests/test_transformers.py
@@ -1,10 +1,14 @@
 import unittest
+from benchutils.tests import testbase
+from benchutils.transformers import metaphlan2_transformer
 
 
-class TestMetaphlan2Transformer(unittest.TestCase):
-    # TODO (blocked by unittest filesystem)
-    # TODO needs sample input
-    pass
+class TestMetaphlan2Transformer(testbase.BaseTestCase):
+
+    def test_metaphlan2_transformer_runs(self):
+        profile = self.get_data_path('sample_metaphlan2_output.txt')
+        output = self.create_data_path('metaphlan2_transformer_output.txt')
+        metaphlan2_transformer(profile, [output], ranks=['genus'])
 
 
 class TestKraken2Transformer(unittest.TestCase):

--- a/benchutils/tests/testbase.py
+++ b/benchutils/tests/testbase.py
@@ -1,0 +1,23 @@
+import unittest
+import pkg_resources
+import os
+
+
+class BaseTestCase(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.to_remove = []
+
+    def get_data_path(self, filename):
+        # adapted from qiime2.plugin.testing.TestPluginBase and biocore/unifrac
+        return pkg_resources.resource_filename(self.package,
+                                               'data/%s' % filename)
+
+    def create_data_path(self, filename):
+        path = self.get_data_path(filename)
+        self.to_remove.append(path)
+        return path
+
+    def tearDown(self) -> None:
+        for file_ in self.to_remove:
+            os.remove(file_)

--- a/benchutils/tests/testbase.py
+++ b/benchutils/tests/testbase.py
@@ -1,5 +1,6 @@
 import unittest
 import pkg_resources
+import benchutils
 import os
 
 
@@ -10,8 +11,8 @@ class BaseTestCase(unittest.TestCase):
 
     def get_data_path(self, filename):
         # adapted from qiime2.plugin.testing.TestPluginBase and biocore/unifrac
-        return pkg_resources.resource_filename(self.package,
-                                               'data/%s' % filename)
+        return pkg_resources.resource_filename(benchutils.__name__,
+                                               'tests/data/%s' % filename)
 
     def create_data_path(self, filename):
         path = self.get_data_path(filename)


### PR DESCRIPTION
Fixes #2 . This PR adds functionality to have test files that are created and removed, as well as have access to the testing files independent of where the tests are run. Some tests that were being blocked by this feature are included as well.