### PR TITLE
Multiple param settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - source activate test-env
   # setup dummy test data
   - chmod +x ci/setup_demo_data.sh
-  - ci/setup_demo_data.sh
+  - zsh ci/setup_demo_data.sh
   # snakemake dry run
   - snakemake -n -r --configfile ci/config.yaml
   # unit tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - source activate test-env
   # setup dummy test data
   - chmod +x ci/setup_demo_data.sh
-  - zsh ci/setup_demo_data.sh
+  - ci/setup_demo_data.sh
   # snakemake dry run
   - snakemake -n -r --configfile ci/config.yaml
   # unit tests

--- a/Snakefile
+++ b/Snakefile
@@ -199,12 +199,31 @@ rule unzip:
     shell:
         "gunzip {input}"
 
-rule copy_profiles:
-    input:
-        "data/profiles/{simname}/{method}/{datetime}_sample_{sample_num}.{rank}.profile.txt"
-    params:
-        loc = "analyses/{wildcards.simname}/profiles/{widlcards.method}/{wildcards.datetime}_sample_{widlcards.sample_num}.{wildcards.rank}.profile.txt"
-    output:
-        "analyses/{simname}/profiles/{method}/{datetime}_sample_{sample_num}.{rank}.profile.txt"
-    shell:
-        "cp {input} {params.loc}"
+SIMC, METHODC, DTC, SNC, RANKC = glob_wildcards("data/profiles/{simname}/{method}/{datetime}_sample_{sample_num}.{rank}.profile.txt")
+input_profiles = expand("data/profiles/{simname}/{method}/{datetime}_sample_{sample_num}.{rank}.profile.txt", zip,
+                        simname=SIMC, method=METHODC, datetime=DTC, sample_num=SNC, rank=RANKC)
+copied_profiles = expand("analyses/{simname}/profiles/{method}/{datetime}_sample_{sample_num}.{rank}.profile.txt", zip,
+                         simname=SIMC, method=METHODC, datetime=DTC, sample_num=SNC, rank=RANKC)
+
+print(input_profiles)
+print(copied_profiles)
+import os
+import shutil
+for src, dest in zip(input_profiles, copied_profiles):
+    if not os.path.isfile(dest):
+        if not os.path.isdir(os.path.dirname(dest)):
+            os.makedirs(os.path.dirname(dest))
+        shutil.copyfile(src, dest)
+
+# rule copy_profiles:
+#     input:
+#         "data/profiles/{simname}/{method}/{datetime}_sample_{sample_num}.{rank}.profile.txt"
+#     params:
+#         loc = "analyses/{wildcards.simname}/profiles/{widlcards.method}/{wildcards.datetime}_sample_{widlcards.sample_num}.{wildcards.rank}.profile.txt"
+#     output:
+#         temp("analyses/{simname}_profiles_{method}_{datetime}_sample_{sample_num}_{rank}_profile_copy.done")
+#     shell:
+#         """
+#         cp {input} {params.loc}
+#         echo '' > {output}
+#         """

--- a/Snakefile
+++ b/Snakefile
@@ -133,9 +133,9 @@ rule kraken2:
 
 rule metaphlan2_transformer:
     input:
-        "analyses/{simname}/profiles/metaphlan2/{datetime}_sample_{sample_num}._all.profile.txt",
+        "analyses/{simname}/profiles/metaphlan2_0/{datetime}_sample_{sample_num}._all.profile.txt",
     output:
-        expand("analyses/{{simname}}/profiles/metaphlan2/{{datetime}}_sample_{{sample_num}}.{{rank}}.profile.txt", rank=RANKS)
+        expand("analyses/{{simname}}/profiles/metaphlan2_0/{{datetime}}_sample_{{sample_num}}.{{rank}}.profile.txt", rank=RANKS)
     run:
         transformers.metaphlan2_transformer(str(input), output, ranks=RANKS)
 
@@ -144,7 +144,7 @@ rule metaphlan2:
     input:
         "data/simulations/{simname}/{datetime}_sample_{sample_num}/reads/" + filename + ".fq"
     output:
-        "analyses/{simname}/profiles/metaphlan2/{datetime}_sample_{sample_num}._all.profile.txt",
+        "analyses/{simname}/profiles/metaphlan2_0/{datetime}_sample_{sample_num}._all.profile.txt",
     conda:
         "envs/taxa-benchmark.yml"
     shell:

--- a/Snakefile
+++ b/Snakefile
@@ -199,3 +199,12 @@ rule unzip:
     shell:
         "gunzip {input}"
 
+rule copy_profiles:
+    input:
+        "data/profiles/{simname}/{method}/{datetime}_sample_{sample_num}.{rank}.profile.txt"
+    params:
+        loc = "analyses/{wildcards.simname}/profiles/{widlcards.method}/{wildcards.datetime}_sample_{widlcards.sample_num}.{wildcards.rank}.profile.txt"
+    output:
+        "analyses/{simname}/profiles/{method}/{datetime}_sample_{sample_num}.{rank}.profile.txt"
+    shell:
+        "cp {input} {params.loc}"

--- a/Snakefile
+++ b/Snakefile
@@ -14,7 +14,7 @@ for method in config["params"]:
         settings = config["params"][method]
         METHODS.extend(method + '_' + str(i) for i in list(range(len(settings))))
     else:
-        METHODS.append(method)
+        METHODS.append(method + '_0')
 
 METRICS = config["metrics"]
 METRIC_COMPARISONS1 = config["metric_comparisons1"]

--- a/Snakefile
+++ b/Snakefile
@@ -12,7 +12,7 @@ METHODS = []
 for method in config["params"]:
     if isinstance(config["params"][method], list):
         settings = config["params"][method]
-        METHODS.extend(method + '_' + str(i) for i in list(range(len(settings))))
+        METHODS.extend(method + '_' + str(i) for i in range(len(settings)))
     else:
         METHODS.append(method + '_0')
 

--- a/benchutils/metrics.py
+++ b/benchutils/metrics.py
@@ -3,6 +3,7 @@ from benchutils import ranks
 import numpy as np
 from numpy.linalg import norm
 from scipy.stats import pearsonr as scipy_pearsonr
+from scipy.stats import spearmanr as scipy_spearmanr
 from scipy.stats import entropy
 from sklearn.metrics import (precision_score, recall_score, f1_score, auc,
                              precision_recall_curve)
@@ -106,6 +107,25 @@ def pearsonr(observed, expected):
 
     """
     return scipy_pearsonr(observed, expected)[0]
+
+
+def spearmanr(observed, expected):
+    """
+
+    Parameters
+    ----------
+    observed : np.array
+        The profile obtained by running a profiling method
+    expected : np.array
+        The ground truth relative abundance
+
+    Returns
+    -------
+    float
+        The Spearman correlation between the series
+
+    """
+    return scipy_spearmanr(observed, expected)[0]
 
 
 def l1_norm(observed, expected):
@@ -312,4 +332,5 @@ available_metrics = {'pearsonr': pearsonr,
                      'l2_norm': l2_norm,
                      'auprc': auprc,
                      'absolute_error': rmse,
-                     'kl_divergence': kl_divergence}
+                     'kl_divergence': kl_divergence,
+                     'spearmanr': spearmanr}

--- a/benchutils/plotting.py
+++ b/benchutils/plotting.py
@@ -143,7 +143,7 @@ def method_comparison_plot(list_of_files, output_file,
 
     # make plot containing all df's concatenated together
     measurements = pd.concat(dfs)
-    measurements['Method'] = ['_'.join(method.split('_')) for method in
+    measurements['Method'] = ['_'.join(method.split('_')[:-1]) for method in
                               measurements['method'].values]
 
     swarmplot_kwargs.update({'hue': 'Method'})

--- a/benchutils/plotting.py
+++ b/benchutils/plotting.py
@@ -2,8 +2,6 @@ import pandas as pd
 import matplotlib.pyplot as plt
 import seaborn as sns
 
-single_setting_models = {"metaphlan2"}
-
 
 def _metric_getter(x): return x.split('.')[-2]
 
@@ -145,8 +143,7 @@ def method_comparison_plot(list_of_files, output_file,
 
     # make plot containing all df's concatenated together
     measurements = pd.concat(dfs)
-    measurements['Method'] = ['_'.join(method.split('_')[:-1]) if method in
-                              single_setting_models else method for
+    measurements['Method'] = ['_'.join(method.split('_')[:-1]) for
                               method in measurements['method'].values]
 
     swarmplot_kwargs.update({'hue': 'Method'})

--- a/benchutils/plotting.py
+++ b/benchutils/plotting.py
@@ -2,6 +2,8 @@ import pandas as pd
 import matplotlib.pyplot as plt
 import seaborn as sns
 
+single_setting_models = {"metaphlan2"}
+
 
 def _metric_getter(x): return x.split('.')[-2]
 
@@ -143,8 +145,9 @@ def method_comparison_plot(list_of_files, output_file,
 
     # make plot containing all df's concatenated together
     measurements = pd.concat(dfs)
-    measurements['Method'] = ['_'.join(method.split('_')[:-1]) for method in
-                              measurements['method'].values]
+    measurements['Method'] = ['_'.join(method.split('_')[:-1]) if method in
+                              single_setting_models else method for
+                              method in measurements['method'].values]
 
     swarmplot_kwargs.update({'hue': 'Method'})
     fig, ax = methods_swarmplot(measurements,

--- a/benchutils/plotting.py
+++ b/benchutils/plotting.py
@@ -141,10 +141,11 @@ def method_comparison_plot(list_of_files, output_file,
     # LOAD list_of_files
     dfs = [_load_summary_series(df_) for df_ in list_of_files]
 
-    dfs['Method'] = ['_'.join(method.split('_')) for method in dfs['method']]
-
     # make plot containing all df's concatenated together
     measurements = pd.concat(dfs)
+    measurements['Method'] = ['_'.join(method.split('_')) for method in
+                              measurements['method'].values]
+
     swarmplot_kwargs.update({'hue': 'Method'})
     fig, ax = methods_swarmplot(measurements,
                                 swarmplot_kwargs=swarmplot_kwargs)

--- a/benchutils/plotting.py
+++ b/benchutils/plotting.py
@@ -141,8 +141,11 @@ def method_comparison_plot(list_of_files, output_file,
     # LOAD list_of_files
     dfs = [_load_summary_series(df_) for df_ in list_of_files]
 
+    dfs['Method'] = ['_'.join(method.split('_')) for method in dfs['method']]
+
     # make plot containing all df's concatenated together
     measurements = pd.concat(dfs)
+    swarmplot_kwargs.update({'hue': 'Method'})
     fig, ax = methods_swarmplot(measurements,
                                 swarmplot_kwargs=swarmplot_kwargs)
     ax.set_xticklabels(ax.get_xticklabels(), rotation=45, ha='right')

--- a/benchutils/tests/test_metrics.py
+++ b/benchutils/tests/test_metrics.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 
 from benchutils.metrics import (precision, recall, f1, l1_norm, l2_norm, auprc,
-                                pearsonr, rmse, profile_error)
+                                pearsonr, spearmanr, rmse, profile_error)
 from benchutils.tests import testbase
 
 
@@ -60,6 +60,13 @@ class TestMetrics(unittest.TestCase):
         expected_pearsonr = numerator / denominator
         observed_pearsonr = pearsonr(obs_profile, exp_profile_orig)
         self.assertAlmostEqual(observed_pearsonr, expected_pearsonr)
+
+    def test_spearmanr_basic(self):
+        exp_profile = np.array([1, 2, 3, 4, 5])
+        obs_profile = np.array([5, 6, 7, 8, 7])
+        observed_spearmanr = spearmanr(obs_profile, exp_profile)
+        expected_spearmanr = 0.82078268166812329
+        self.assertAlmostEqual(observed_spearmanr, expected_spearmanr)
 
     def test_l1_norm_basic(self):
         input_ = pd.Series([0, 0.1, 0.3, 0.1, 0.5])
@@ -126,6 +133,14 @@ class TestProfileError(testbase.BaseTestCase):
                       methods='pearsonr', metric='pearsonr')
         profile_error([self.obs1, self.obs1], self.exp, out2, rank='genus',
                       methods=['pearsonr', 'pearsonr'], metric='pearsonr')
+
+    def test_runs_metric_spearmanr(self):
+        out1 = self.create_data_path('test_runs_with_metric_spearmanr1.txt')
+        out2 = self.create_data_path('test_runs_with_metric_spearmanr2.txt')
+        profile_error(self.obs1, self.exp, out1, rank='genus',
+                      methods='spearmanr', metric='spearmanr')
+        profile_error([self.obs1, self.obs1], self.exp, out2, rank='genus',
+                      methods=['spearmanr', 'spearmanr'], metric='spearmanr')
 
     def test_runs_metric_rmse(self):
         out1 = self.create_data_path('test_runs_with_metric_rmse1.txt')

--- a/benchutils/transformers.py
+++ b/benchutils/transformers.py
@@ -75,14 +75,14 @@ def metaphlan2_transformer(all_rank_summary, output_rank_summaries, ranks):
         sub_df_matching.to_csv(output_, sep='\t', index=False)
 
 
-def mohawk_transformer(per_read_summary, output_summary):
+def mohawk_transformer(per_read_summary, output_summary, threshold=0.0):
     # TODO this is a work in progress, concurrent with the stage of mohawk
     all_reads = pd.read_csv(per_read_summary, sep='\t')
     vc = all_reads.iloc[:, 1].value_counts()
-    df = pd.DataFrame(vc / vc.sum())
+    df1 = pd.DataFrame(vc / vc.sum())
     # zero out entries less than 1/10 of a percent
-    df = (df > 0.001) * df
-    df = 100 * df / df.sum()
+    df1 = (df1 >= threshold) * df1
+    df = 100 * df1 / df1.sum()
     df.columns = ['PERCENTAGE']
     df.index.name = '@@TAXID'
     df.reset_index(inplace=True)

--- a/ci/config.yaml
+++ b/ci/config.yaml
@@ -13,3 +13,11 @@ metric_comparisons2:
   ['absolute_error', 'auprc']
 mohawk_model:
   "ci/test_model.mod"
+
+params:
+  {
+    "kraken2": [{"db": "/projects/genome_annotation/ref107/dbs/kraken2"},
+                {"db": "/projects/genome_annotation/ref107/dbs/kraken2_alt"}],
+    "metaphlan2": None,
+    "mohawk": [{"model": "/home/garmstro/gwarmstrong-repos/mohawk/runs/Sep05_16-33-46_brncl-34.ucsd.edu/models/trained_model_epoch_25_seed_1234.mod"}]
+  }

--- a/ci/config.yaml
+++ b/ci/config.yaml
@@ -1,23 +1,27 @@
-kraken2_db:
-    "/path/to/db"
 ranks:
-    # if not in a list, it will mess up
-    ["genus"]
+  # if not in a list, it will mess up (same for all below)
+  ["genus", "family"]
 methods:
-  ["kraken2", "metaphlan2", "mohawk"] # "shogun"]
+  ["kraken2", "metaphlan2", "mohawk", "blah"]
 metrics:
-  ['pearsonr', 'l2_norm', 'auprc', 'absolute_error']
+  ['pearsonr', 'l2_norm', 'l1_norm', 'auprc', 'absolute_error', 'kl_divergence', 'f1',
+   'precision', 'recall', 'spearmanr']
 metric_comparisons1:
   ['l2_norm', 'l2_norm']
 metric_comparisons2:
   ['absolute_error', 'auprc']
-mohawk_model:
-  "ci/test_model.mod"
 
 params:
   {
-    "kraken2": [{"db": "/projects/genome_annotation/ref107/dbs/kraken2"},
-                {"db": "/projects/genome_annotation/ref107/dbs/kraken2_alt"}],
+    "kraken2": [
+      {"db": "ci/dbs/kraken_db1"},
+      {"db": "ci/dbs/kraken_db2"}
+    ],
     "metaphlan2": None,
-    "mohawk": [{"model": "/home/garmstro/gwarmstrong-repos/mohawk/runs/Sep05_16-33-46_brncl-34.ucsd.edu/models/trained_model_epoch_25_seed_1234.mod"}]
+    "mohawk": [
+      {"model": "ci/dbs/test_mohawk1.mod"},
+      {"model": "ci/dbs/test_mohawk2.mod"},
+      {"model": "ci/dbs/test_mohawk3.mod"},
+      {"model": "ci/dbs/test_mohawk4.mod"}
+    ]
   }

--- a/ci/setup_demo_data.sh
+++ b/ci/setup_demo_data.sh
@@ -9,4 +9,8 @@ echo '' > data/simulations/test-sim2/taxonomic_profile_0.txt
 echo '' > data/simulations/test-sim1/taxonomic_profile_1.txt
 echo '' > data/simulations/test-sim3/taxonomic_profile_0.txt
 mkdir -p data/profiles/test-sim{1,2,3}/blah/
-echo '' > data/profiles/test-sim{1,2,3}/blah/fake_date_sample_{0,1}.family.profile.txt
+echo '' > data/profiles/test-sim{1,2}/blah/fake_date_sample_{0,1}.family.profile.txt
+echo '' > data/profiles/test-sim{1,2}/blah/fake_date_sample_{0,1}.genus.profile.txt
+mkdir -p data/profiles/test-sim{1,2,3}/mohawk_{0,1,2,3}/
+echo '' > data/profiles/test-sim{1,2,3}/mohawk_{0,1,2,3}/fake_date_sample_{0,1}.family.profile.txt
+echo '' > data/profiles/test-sim3/mohawk_{0,1,2,3}/fake_date3_sample_0.family.profile.txt

--- a/ci/setup_demo_data.sh
+++ b/ci/setup_demo_data.sh
@@ -9,8 +9,16 @@ echo '' > data/simulations/test-sim2/taxonomic_profile_0.txt
 echo '' > data/simulations/test-sim1/taxonomic_profile_1.txt
 echo '' > data/simulations/test-sim3/taxonomic_profile_0.txt
 mkdir -p data/profiles/test-sim{1,2,3}/blah/
-echo '' > data/profiles/test-sim{1,2}/blah/fake_date_sample_{0,1}.family.profile.txt
-echo '' > data/profiles/test-sim{1,2}/blah/fake_date_sample_{0,1}.genus.profile.txt
+for eachfile in data/profiles/test-sim{1,2}/blah/fake_date_sample_{0,1}.family.profile.txt; do
+  echo '' > $eachfile
+done
+for eachfile in data/profiles/test-sim{1,2}/blah/fake_date_sample_{0,1}.genus.profile.txt; do
+  echo '' > $eachfile
+done
 mkdir -p data/profiles/test-sim{1,2,3}/mohawk_{0,1,2,3}/
-echo '' > data/profiles/test-sim{1,2,3}/mohawk_{0,1,2,3}/fake_date_sample_{0,1}.family.profile.txt
-echo '' > data/profiles/test-sim3/mohawk_{0,1,2,3}/fake_date3_sample_0.family.profile.txt
+for eachfile in data/profiles/test-sim{1,2,3}/mohawk_{0,1,2,3}/fake_date_sample_{0,1}.family.profile.txt; do
+  echo '' > $eachfile
+done
+for eachfile in data/profiles/test-sim3/mohawk_{0,1,2,3}/fake_date3_sample_0.family.profile.txt; do
+  echo '' > $eachfile
+done

--- a/ci/setup_demo_data.sh
+++ b/ci/setup_demo_data.sh
@@ -8,3 +8,5 @@ echo '' > data/simulations/test-sim1/taxonomic_profile_0.txt
 echo '' > data/simulations/test-sim2/taxonomic_profile_0.txt
 echo '' > data/simulations/test-sim1/taxonomic_profile_1.txt
 echo '' > data/simulations/test-sim3/taxonomic_profile_0.txt
+mkdir -p data/profiles/test-sim{1,2,3}/blah/
+echo '' > data/profiles/test-sim{1,2,3}/blah/fake_date_sample_{0,1}.family.profile.txt

--- a/config.yaml
+++ b/config.yaml
@@ -13,3 +13,10 @@ metric_comparisons2:
     ['absolute_error', 'auprc']
 mohawk_model:
     "/home/garmstro/gwarmstrong-repos/mohawk/runs/Sep05_16-33-46_brncl-34.ucsd.edu/models/trained_model_epoch_25_seed_1234.mod"
+
+params:
+  {
+   "kraken2": [{"db": "/projects/genome_annotation/ref107/dbs/kraken2"}],
+   "metaphlan2": None,
+   "mohawk": [{"model": "/home/garmstro/gwarmstrong-repos/mohawk/runs/Sep05_16-33-46_brncl-34.ucsd.edu/models/trained_model_epoch_25_seed_1234.mod"}]
+  }

--- a/config.yaml
+++ b/config.yaml
@@ -4,9 +4,10 @@ ranks:
     # if not in a list, it will mess up (same for all below)
     ["genus"]
 methods:
-    ["kraken2", "metaphlan2", "CNN"]
+    ["kraken2", "metaphlan2", "mohawk"]
 metrics:
-    ['pearsonr', 'l2_norm', 'auprc', 'absolute_error', 'kl_divergence']
+    ['pearsonr', 'l2_norm', 'l1_norm', 'auprc', 'absolute_error', 'kl_divergence', 'f1',
+     'precision', 'recall', 'spearmanr']
 metric_comparisons1:
     ['l2_norm', 'l2_norm']
 metric_comparisons2:
@@ -16,7 +17,15 @@ mohawk_model:
 
 params:
   {
-   "kraken2": [{"db": "/projects/genome_annotation/ref107/dbs/kraken2"}],
+   "kraken2": [
+                {"db": "/projects/genome_annotation/ref107/dbs/kraken2"},
+                {"db": "/panfs/panfs1.ucsd.edu/panscratch/garmstro/kraken_db/kraken-standard"}
+              ],
    "metaphlan2": None,
-   "mohawk": [{"model": "/home/garmstro/gwarmstrong-repos/mohawk/runs/Sep05_16-33-46_brncl-34.ucsd.edu/models/trained_model_epoch_25_seed_1234.mod"}]
+   "mohawk": [
+                {"model": "/home/garmstro/gwarmstrong-repos/mohawk/runs/Sep05_16-33-46_brncl-34.ucsd.edu/models/trained_model_epoch_20_seed_1234.mod"},
+                {"model": "/home/garmstro/gwarmstrong-repos/mohawk/runs/Sep05_16-33-46_brncl-34.ucsd.edu/models/trained_model_epoch_25_seed_1234.mod"},
+                {"model": "/home/garmstro/gwarmstrong-repos/mohawk/runs/Sep09_12-09-35_brncl-34.ucsd.edu/models/trained_model_epoch_95_seed_1234.mod"},
+                {"model": "/home/garmstro/gwarmstrong-repos/mohawk/runs/Sep10_13-48-31_brncl-34.ucsd.edu/models/trained_model_epoch_95_seed_1234.mod"}
+             ]
   }


### PR DESCRIPTION
Addresses #5 and #6 

### Short summary of changes:

Multiple parameter settings are now allowed. This is supported by including a JSON like  model/database specification in the `config.yaml` file, e.g.:

https://github.com/gwarmstrong/taxa-assign-benchmarking/blob/bae996059fee13002c19c646a1672acd9bb3a3c9/ci/config.yaml#L14-L27

Which would produce plots that look like the following:
![Screen Shot 2019-10-08 at 6 05 29 PM](https://user-images.githubusercontent.com/19470970/66444017-5e031e00-e9f6-11e9-9865-bd032e92bd3a.png)

Additionally, pre-computed profiles can be incorporated by adding them to the `data/profiles/{simname}/{method}/` directory with a name that matches what the profile will be referred to as later.

There is one additional small change, which is the addition of the `spearmanr` metric.